### PR TITLE
Add concurrent producer-consumer

### DIFF
--- a/parallel/producerconsumer.go
+++ b/parallel/producerconsumer.go
@@ -1,0 +1,111 @@
+package parallel
+
+import (
+	"sync"
+	"errors"
+)
+
+type ErrorHandler func(error)
+
+type Producer interface {
+	AddTask(Task) error
+	AddTaskWithError(Task, ErrorHandler) error
+	Close()
+}
+
+type Consumer interface {
+	Run()
+	StopProducer()
+}
+
+type Task func(int) error
+
+type TaskWrapper struct {
+	task    Task
+	onError ErrorHandler
+}
+
+type ProducerConsumer struct {
+	tasks          chan TaskWrapper
+	cancel         chan struct{}
+	numOfConsumers int
+	failFast       bool
+}
+
+// Create new ProducerConsumer.
+// numOfConsumers - number of go routines which do the actually consuming, numOfConsumers always will be a positive number.
+// isFailFast - is set to true the will stop on first error.
+func NewProducerConsumer(numOfConsumers int, isFailFast bool) *ProducerConsumer {
+	consumers := numOfConsumers
+	if consumers < 1 {
+		consumers = 1
+	}
+	return &ProducerConsumer{
+		tasks: make(chan TaskWrapper),
+		cancel: make(chan struct{}),
+		numOfConsumers: consumers,
+		failFast: isFailFast,
+	}
+}
+
+// Add a task to the producer channel, in case of cancellation event (caused by @StopProducer()) will return non nil error.
+func (pc *ProducerConsumer) AddTask(t Task) error {
+	taskWrapper := TaskWrapper{task:t, onError:func(err error) {}}
+	return pc.sendNewTask(taskWrapper)
+}
+
+// t - the actual task which will be performed by the consumer.
+// errorHandler - execute on the returned error while running t
+func (pc *ProducerConsumer) AddTaskWithError(t Task, errorHandler ErrorHandler) error {
+	taskWrapper := TaskWrapper{task:t, onError:errorHandler}
+	return pc.sendNewTask(taskWrapper)
+}
+
+func (pc *ProducerConsumer) sendNewTask(taskWrapper TaskWrapper) error {
+	select {
+	case pc.tasks <- taskWrapper:
+		return nil
+	case <-pc.cancel:
+		return errors.New("Producer stopped")
+	}
+}
+
+// The producer notify that no more task will be produced.
+func (pc *ProducerConsumer) Close() {
+	close(pc.tasks)
+}
+
+// Run pc.numOfConsumers go routines in order to consume all the tasks in pc.getTasks().
+// If a task return an error all the go routines will stop and a the producer will be notified.
+// Notice: Consume() is a blocking operation.
+func (pc *ProducerConsumer) Run() {
+	var wg sync.WaitGroup
+	var once sync.Once
+	for i := 0; i < pc.numOfConsumers; i++ {
+		wg.Add(1)
+		go func(threadId int) {
+			defer func() {
+				wg.Done()
+			}()
+			for taskWrapper := range pc.getTasks() {
+				e := taskWrapper.task(threadId)
+				if e != nil {
+					taskWrapper.onError(e)
+					if pc.failFast {
+						once.Do(pc.StopProducer)
+						break
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func (pc *ProducerConsumer) getTasks() <- chan TaskWrapper {
+	return pc.tasks
+}
+
+func (pc *ProducerConsumer) StopProducer() {
+	close(pc.cancel)
+}

--- a/parallel/producerconsumer_test.go
+++ b/parallel/producerconsumer_test.go
@@ -1,0 +1,250 @@
+package parallel
+
+import (
+	"testing"
+	"fmt"
+	"time"
+	"sync"
+	"math/rand"
+	"errors"
+	"strings"
+	"strconv"
+)
+
+const numOfProducerCycles = 100
+const numOfConsumers = 10
+
+type taskCreatorFunc func(int, chan int) Task
+
+var rndSrc = rand.NewSource(time.Now().UnixNano())
+var random = rand.New(src)
+
+func TestSuccessfulFlow(t *testing.T) {
+	var expectedTotal int
+	results := make(chan int, numOfProducerCycles)
+	runner := NewProducerConsumer(numOfConsumers, true);
+	errorsQueue := NewErrorsQueue(1)
+	var wg sync.WaitGroup
+
+	// Produce
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+		}()
+		expectedTotal = produceTasks(runner, results, errorsQueue, createSuccessfulFlowTaskFunc)
+	}()
+
+	// Consume
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+			close(results)
+		}()
+		runner.Run()
+	}()
+
+	wg.Wait()
+	checkResult(expectedTotal, results, t)
+}
+
+func TestStopOperationsOnTaskError(t *testing.T) {
+	expectedTotal := 1275
+	results := make(chan int, numOfProducerCycles)
+	runner := NewProducerConsumer(numOfConsumers, true);
+	errorsQueue := NewErrorsQueue(1)
+	var wg sync.WaitGroup
+
+	// Produce
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+		}()
+		produceTasks(runner, results, errorsQueue, createTaskWithErrorFunc)
+	}()
+
+	// Consume
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+			close(results)
+		}()
+		runner.Run()
+	}()
+
+	wg.Wait()
+	err := errorsQueue.GetError().Error()
+	if !strings.Contains(err, "above 50 going to stop") {
+		t.Error("Unexpected Error message. Expected: num: 51, above 50 going to stop", "Got:", err)
+	}
+	checkResult(expectedTotal, results, t)
+}
+
+func TestContinueOperationsOnTaskError(t *testing.T) {
+	expectedTotal := 1275
+	errorsExpectedTotal := 3675
+	results := make(chan int, numOfProducerCycles)
+	errorsQueue := NewErrorsQueue(100)
+	runner := NewProducerConsumer(numOfConsumers, false)
+	var wg sync.WaitGroup
+
+	// Produce
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+		}()
+		produceTasks(runner, results, errorsQueue, createTaskWithIntAsErrorFunc)
+	}()
+
+	// Consume
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+			close(results)
+		}()
+		runner.Run()
+	}()
+
+	wg.Wait()
+	checkResult(expectedTotal, results, t)
+	checkErrorsResult(errorsExpectedTotal, errorsQueue, t)
+}
+
+func TestFailFastOnTaskError(t *testing.T) {
+	expectedTotal := 1275
+	errorsExpectedTotal := 51
+	results := make(chan int, numOfProducerCycles)
+	errorsQueue := NewErrorsQueue(100)
+	runner := NewProducerConsumer(numOfConsumers, true)
+	var wg sync.WaitGroup
+
+	// Produce
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+		}()
+		produceTasks(runner, results, errorsQueue, createTaskWithIntAsErrorFunc)
+	}()
+
+	// Consume
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+			close(results)
+		}()
+		runner.Run()
+	}()
+
+	wg.Wait()
+	checkResult(expectedTotal, results, t)
+	checkErrorsResult(errorsExpectedTotal, errorsQueue, t)
+}
+
+func checkErrorsResult(errorsExpectedTotal int, errorsQueue *ErrorsQueue, t *testing.T) {
+	resultsTotal := 0
+	for {
+		err := errorsQueue.GetError()
+		if err == nil {
+			break
+		}
+		x, _ := strconv.Atoi(err.Error())
+		resultsTotal += x
+	}
+	if resultsTotal != errorsExpectedTotal {
+		t.Error("Unexpected results total. Expected:", errorsExpectedTotal, "Got:", resultsTotal)
+	}
+}
+
+func checkResult(expectedTotal int, results <- chan int, t *testing.T) {
+	var resultsTotal int
+	for result := range results {
+		resultsTotal += result
+	}
+	if resultsTotal != expectedTotal {
+		t.Error("Unexpected results total. Expected:", expectedTotal, "Got:", resultsTotal)
+	}
+}
+
+func produceTasks(producer Producer, results chan int, errorsQueue *ErrorsQueue, taskCreator taskCreatorFunc) int {
+	defer producer.Close()
+	var expectedTotal int
+	for i := 0; i < numOfProducerCycles; i++ {
+		taskFunc := taskCreator(i, results)
+		err := producer.AddTaskWithError(taskFunc, errorsQueue.AddErrorNonBlocking)
+		if err != nil {
+			break
+		}
+		expectedTotal += i
+	}
+	fmt.Println("Producer done")
+	return expectedTotal
+}
+
+func createSuccessfulFlowTaskFunc(num int, result chan int) Task {
+	return func(threadId int) error {
+		result <- num
+		time.Sleep(time.Millisecond * time.Duration(random.Intn(50)))
+		fmt.Printf("[Thread %d] %d\n", threadId, num)
+		return nil
+	}
+}
+
+func createTaskWithErrorFunc(num int, result chan int) Task {
+	return func(threadId int) error {
+		if num > 50 {
+			return errors.New(fmt.Sprintf("num: %d, above 50 going to stop.", num))
+		}
+		result <- num
+		time.Sleep(time.Millisecond * time.Duration(random.Intn(50)))
+		fmt.Printf("[Thread %d] %d\n", threadId, num)
+		return nil
+	}
+}
+
+func createTaskWithIntAsErrorFunc(num int, result chan int) Task {
+	return func(threadId int) error {
+		if num > 50 {
+			return errors.New(fmt.Sprintf("%d", num))
+		}
+		result <- num
+		time.Sleep(time.Millisecond * time.Duration(random.Intn(50)))
+		fmt.Printf("[Thread %d] %d\n", threadId, num)
+		return nil
+	}
+}
+
+type ErrorsQueue struct {
+	errorsChan chan (error)
+}
+
+func NewErrorsQueue(size int) *ErrorsQueue {
+	queueSize := 1
+	if size > 1 {
+		queueSize = size
+	}
+	return &ErrorsQueue{errorsChan:make(chan error, queueSize)}
+}
+
+func (errQueue *ErrorsQueue) AddErrorNonBlocking(err error) {
+	select {
+	case errQueue.errorsChan <- err:
+	default:
+		return
+	}
+}
+
+func (errQueue *ErrorsQueue) GetError() error {
+	select {
+	case err := <-errQueue.errorsChan:
+		return err
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
I made the changes you asked for except of adding an error per task. 
Instead, I provided an example in the tests how to accumulate errors using an errors queue struct. 