### PR TITLE
Fix a bug where runner would run forever in case of error in failFast…

### DIFF
--- a/parallel/bounded_runner_test.go
+++ b/parallel/bounded_runner_test.go
@@ -125,7 +125,6 @@ func TestFailFastOnTaskError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			runner.Done()
 			wg.Done()
 		}()
 		produceTasks(runner, results, errorsQueue, createTaskWithIntAsErrorFunc)
@@ -188,7 +187,7 @@ func checkResult(expectedTotal int, results <-chan int, t *testing.T) {
 }
 
 func produceTasks(runner *runner, results chan int, errorsQueue *ErrorsQueue, taskCreator taskCreatorFunc) int {
-	defer runner.Close()
+	defer runner.Done()
 	var expectedTotal int
 	for i := 0; i < numOfProducerCycles; i++ {
 		taskFunc := taskCreator(i, results)


### PR DESCRIPTION
… mode, because Done() did not close the tasks channel. Also, removed Close() since it was not needed. New Done() is identical to old Close()