### PR TITLE
Update Go to v1.18 and Add Generic Set data structure

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Static Code Analysis
         uses: dominikh/staticcheck-action@v1
 
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Install gosec
         run: curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
       - name: Run gosec

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,9 +9,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Static Code Analysis
         uses: dominikh/staticcheck-action@v1
+        install-go: false
 
   Go-Sec:
     runs-on: ubuntu-latest
@@ -21,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Install gosec
         run: curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
       - name: Run gosec

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,8 @@ jobs:
           go-version: 1.18.x
       - name: Static Code Analysis
         uses: dominikh/staticcheck-action@v1
-        install-go: false
+        with:
+          install-go: false
 
   Go-Sec:
     runs-on: ubuntu-latest

--- a/.github/workflows/frogbot-fix-go.yml
+++ b/.github/workflows/frogbot-fix-go.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Install prerequisites
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
 

--- a/.github/workflows/frogbot-fix-go.yml
+++ b/.github/workflows/frogbot-fix-go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - uses: jfrog/frogbot@v2
         env:

--- a/.github/workflows/frogbot-scan-pr-go.yml
+++ b/.github/workflows/frogbot-scan-pr-go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - uses: jfrog/frogbot@v2
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Go Cache
         uses: actions/cache@v3

--- a/datastructures/set.go
+++ b/datastructures/set.go
@@ -1,0 +1,45 @@
+package datastructures
+
+import "fmt"
+
+type Set[T comparable] struct {
+	container map[T]struct{}
+}
+
+//MakeSet initialize the set
+func MakeSet[T comparable]() *Set[T] {
+	return &Set[T]{
+		container: make(map[T]struct{}),
+	}
+}
+
+func (set *Set[T]) Exists(key T) bool {
+	_, exists := set.container[key]
+	return exists
+}
+
+func (set *Set[T]) Add(key T) {
+	set.container[key] = struct{}{}
+}
+
+func (set *Set[T]) Remove(key T) error {
+	_, exists := set.container[key]
+	if !exists {
+		return fmt.Errorf("remove Error: item doesn't exist in set")
+	}
+	delete(set.container, key)
+	return nil
+}
+
+func (set *Set[T]) Size() int {
+	return len(set.container)
+}
+
+func (set *Set[T]) ToSlice() []T {
+	var slice []T
+	for key := range set.container {
+		slice = append(slice, key)
+	}
+
+	return slice
+}

--- a/datastructures/set_test.go
+++ b/datastructures/set_test.go
@@ -1,0 +1,37 @@
+package datastructures
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func generateNewSetWithData() *Set[int] {
+	set := MakeSet[int]()
+	set.Add(3)
+	set.Add(5)
+	set.Add(7)
+
+	return set
+}
+
+func TestSetExistsAndAdd(t *testing.T) {
+	testSet := generateNewSetWithData()
+	assert.True(t, testSet.Exists(3))
+	assert.False(t, testSet.Exists(4))
+}
+
+func TestSetRemove(t *testing.T) {
+	testSet := generateNewSetWithData()
+	assert.NoError(t, testSet.Remove(5))
+	assert.Equal(t, testSet.Size(), 2)
+	assert.False(t, testSet.Exists(5))
+}
+
+func TestSetToSlice(t *testing.T) {
+	testSet := generateNewSetWithData()
+	slice := testSet.ToSlice()
+	assert.Equal(t, len(slice), 3)
+	assert.Contains(t, slice, 3)
+	assert.Contains(t, slice, 5)
+	assert.Contains(t, slice, 7)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,10 @@ require (
 	github.com/stretchr/testify v1.8.0
 )
 
-go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
+go 1.18
+
 module github.com/jfrog/gofrog
 
 require (
-	github.com/pkg/errors v0.8.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 )
 
@@ -10,5 +12,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-go 1.18

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gofrog#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] I labeled this pull request with one of the following: 'breaking change', 'new feature', 'bug', or 'ignore for release'

---
- Update gofrog to Go v1.18
- Add Generic Set data structure