### PR TITLE
Fix race conditions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
         run: go vet ./...
 
       - name: Tests
-        run: go test ./... -v
+        run: go test ./... -v -race

--- a/parallel/bounded_runner_test.go
+++ b/parallel/bounded_runner_test.go
@@ -15,9 +15,6 @@ const numOfConsumers = 10
 
 type taskCreatorFunc func(int, chan int) TaskFunc
 
-var rndSrc = rand.NewSource(time.Now().UnixNano())
-var random = rand.New(rndSrc)
-
 func TestSuccessfulFlow(t *testing.T) {
 	var expectedTotal int
 	results := make(chan int, numOfProducerCycles)
@@ -202,7 +199,7 @@ func produceTasks(runner *runner, results chan int, errorsQueue *ErrorsQueue, ta
 func createSuccessfulFlowTaskFunc(num int, result chan int) TaskFunc {
 	return func(threadId int) error {
 		result <- num
-		time.Sleep(time.Millisecond * time.Duration(random.Intn(50)))
+		time.Sleep(time.Millisecond * time.Duration(rand.Intn(50)))
 		return nil
 	}
 }
@@ -213,7 +210,7 @@ func createTaskWithErrorFunc(num int, result chan int) TaskFunc {
 			return fmt.Errorf("num: %d, above 50 going to stop.", num)
 		}
 		result <- num
-		time.Sleep(time.Millisecond * time.Duration(random.Intn(50)))
+		time.Sleep(time.Millisecond * time.Duration(rand.Intn(50)))
 		return nil
 	}
 }
@@ -224,7 +221,7 @@ func createTaskWithIntAsErrorFunc(num int, result chan int) TaskFunc {
 			return fmt.Errorf("%d", num)
 		}
 		result <- num
-		time.Sleep(time.Millisecond * time.Duration(random.Intn(50)))
+		time.Sleep(time.Millisecond * time.Duration(rand.Intn(50)))
 		return nil
 	}
 }

--- a/parallel/runner_test.go
+++ b/parallel/runner_test.go
@@ -8,9 +8,6 @@ import (
 	"time"
 )
 
-var src = rand.NewSource(time.Now().UnixNano())
-var rnd = rand.New(src)
-
 func TestTask(t *testing.T) {
 	const count = 70
 	results := make(chan int, 100)
@@ -27,7 +24,7 @@ func TestTask(t *testing.T) {
 		x := i
 		runner.AddTask(func(i int) error {
 			results <- x
-			time.Sleep(time.Millisecond * time.Duration(rnd.Intn(50)))
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(50)))
 			if float64(x) > math.Floor(float64(count)/2) {
 				return fmt.Errorf("Second half value %d not counted", x)
 			}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gofrog#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] I labeled this pull request with one of the following: 'breaking change', 'new feature', 'bug', or 'ignore for release'

---

Fix 2 race conditions in runner:
1. False positive - two concurrent threads may set started boolean to true. Fixed by changing it to unit32 + atomic.
2. Stop using "rndSrc" and "random" variables in tests. Instead, use `rand.Intn(50)`.