### PR TITLE
Add semantic versioning extraction utility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/mod v0.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/io/cmd.go
+++ b/io/cmd.go
@@ -84,11 +84,23 @@ func RunCmdWithOutputParser(config CmdConfig, prompt bool, regExpStruct ...*CmdO
 		return
 	}
 	scanner := bufio.NewScanner(cmdReader)
+	defer func() {
+		closeErr := cmdReader.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	cmdReaderStderr, err := cmd.StderrPipe()
 	if err != nil {
 		return
 	}
 	scannerStderr := bufio.NewScanner(cmdReaderStderr)
+	defer func() {
+		closeErr := cmdReaderStderr.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	err = cmd.Start()
 	if err != nil {
 		return
@@ -162,8 +174,8 @@ func RunCmdWithOutputParser(config CmdConfig, prompt bool, regExpStruct ...*CmdO
 	exitOk = true
 	if _, ok := err.(*exec.ExitError); ok {
 		// The program has exited with an exit code != 0
-		err = cmdReader.Close()
-		err = cmdReaderStderr.Close()
+		//err = cmdReader.Close()
+		//err = cmdReaderStderr.Close()
 		exitOk = false
 	}
 	return

--- a/io/cmd.go
+++ b/io/cmd.go
@@ -174,8 +174,6 @@ func RunCmdWithOutputParser(config CmdConfig, prompt bool, regExpStruct ...*CmdO
 	exitOk = true
 	if _, ok := err.(*exec.ExitError); ok {
 		// The program has exited with an exit code != 0
-		//err = cmdReader.Close()
-		//err = cmdReaderStderr.Close()
 		exitOk = false
 	}
 	return

--- a/io/cmd.go
+++ b/io/cmd.go
@@ -83,13 +83,11 @@ func RunCmdWithOutputParser(config CmdConfig, prompt bool, regExpStruct ...*CmdO
 	if err != nil {
 		return
 	}
-	defer cmdReader.Close()
 	scanner := bufio.NewScanner(cmdReader)
 	cmdReaderStderr, err := cmd.StderrPipe()
 	if err != nil {
 		return
 	}
-	defer cmdReaderStderr.Close()
 	scannerStderr := bufio.NewScanner(cmdReaderStderr)
 	err = cmd.Start()
 	if err != nil {
@@ -152,6 +150,8 @@ func RunCmdWithOutputParser(config CmdConfig, prompt bool, regExpStruct ...*CmdO
 	}()
 
 	for err = range errChan {
+		err = cmdReader.Close()
+		err = cmdReaderStderr.Close()
 		return
 	}
 
@@ -162,6 +162,8 @@ func RunCmdWithOutputParser(config CmdConfig, prompt bool, regExpStruct ...*CmdO
 	exitOk = true
 	if _, ok := err.(*exec.ExitError); ok {
 		// The program has exited with an exit code != 0
+		err = cmdReader.Close()
+		err = cmdReaderStderr.Close()
 		exitOk = false
 	}
 	return

--- a/version/version.go
+++ b/version/version.go
@@ -64,6 +64,17 @@ func (v *Version) AtLeast(minVersion string) bool {
 	return v.Compare(minVersion) <= 0
 }
 
+func (v *Version) GetMajor() string {
+	return strings.Split(v.version, ".")[0]
+}
+
+func (v *Version) GetMinor() string {
+	return strings.Split(v.version, ".")[1]
+}
+func (v *Version) GetPatch() string {
+	return strings.Split(v.version, ".")[2]
+}
+
 func compareTokens(ver1Token, ver2Token string) int {
 	if ver1Token == ver2Token {
 		return 0

--- a/version/version.go
+++ b/version/version.go
@@ -2,13 +2,10 @@ package version
 
 import (
 	"errors"
-	"regexp"
+	"golang.org/x/mod/semver"
 	"strconv"
 	"strings"
 )
-
-// Taken from official docs https://semver.org/
-const regex = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
 
 type Version struct {
 	version string
@@ -78,16 +75,9 @@ func (v *Version) GetMinor() (string, error) {
 func (v *Version) GetPatch() (string, error) {
 	return v.extractPosition(2)
 }
-func (v *Version) IsSemanticFormat() bool {
-	r, err := regexp.Compile(regex)
-	if err != nil {
-		return false
-	}
-	return r.MatchString(v.version)
-}
 
 func (v *Version) extractPosition(index int) (string, error) {
-	if !v.IsSemanticFormat() {
+	if semver.IsValid(v.version) {
 		return "", errors.New("invalid semantic versions format")
 	}
 	return strings.Split(v.version, ".")[index], nil

--- a/version/version.go
+++ b/version/version.go
@@ -2,9 +2,13 @@ package version
 
 import (
 	"errors"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// Taken from official docs https://semver.org/
+const regex = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
 
 type Version struct {
 	version string
@@ -75,7 +79,11 @@ func (v *Version) GetPatch() (string, error) {
 	return v.extractPosition(2)
 }
 func (v *Version) IsSemanticFormat() bool {
-	return strings.Count(v.GetVersion(), ".") == 2
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return false
+	}
+	return r.MatchString(v.version)
 }
 
 func (v *Version) extractPosition(index int) (string, error) {

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 )
@@ -64,15 +65,24 @@ func (v *Version) AtLeast(minVersion string) bool {
 	return v.Compare(minVersion) <= 0
 }
 
-func (v *Version) GetMajor() string {
-	return strings.Split(v.version, ".")[0]
+func (v *Version) GetMajor() (string, error) {
+	return v.extractPosition(0)
+}
+func (v *Version) GetMinor() (string, error) {
+	return v.extractPosition(1)
+}
+func (v *Version) GetPatch() (string, error) {
+	return v.extractPosition(2)
+}
+func (v *Version) IsSemanticFormat() bool {
+	return strings.Count(v.GetVersion(), ".") == 2
 }
 
-func (v *Version) GetMinor() string {
-	return strings.Split(v.version, ".")[1]
-}
-func (v *Version) GetPatch() string {
-	return strings.Split(v.version, ".")[2]
+func (v *Version) extractPosition(index int) (string, error) {
+	if !v.IsSemanticFormat() {
+		return "", errors.New("invalid semantic versions format")
+	}
+	return strings.Split(v.version, ".")[index], nil
 }
 
 func compareTokens(ver1Token, ver2Token string) int {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -105,10 +105,10 @@ func TestGetSemantics(t *testing.T) {
 			minor:       "2",
 			patch:       "3",
 		}, {
-			fullVersion: Version{"0.2.3"},
-			major:       "0",
-			minor:       "2",
-			patch:       "3",
+			fullVersion: Version{"40.23.32"},
+			major:       "40",
+			minor:       "23",
+			patch:       "32",
 		},
 	}
 	for _, test := range tests {
@@ -123,28 +123,6 @@ func TestGetSemantics(t *testing.T) {
 			assert.Equal(t, test.major, major)
 			assert.Equal(t, test.minor, minor)
 			assert.Equal(t, test.patch, patch)
-		})
-	}
-}
-
-func TestGetSemanticsInvalidFormat(t *testing.T) {
-	tests := []struct {
-		fullVersion Version
-		major       string
-		minor       string
-		patch       string
-	}{
-		{
-			fullVersion: Version{"1.2"},
-			major:       "1",
-			minor:       "2",
-			patch:       "",
-		},
-	}
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			_, err := test.fullVersion.GetMajor()
-			assert.Error(t, err)
 		})
 	}
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,6 +1,9 @@
 package version
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestCompare(t *testing.T) {
 	tests := []struct {
@@ -79,6 +82,40 @@ func TestAtLeast(t *testing.T) {
 			if result != test.expected {
 				t.Error("ver1:", test.ver1, "ver2:", test.ver2, "Expecting:", test.expected, "got:", result)
 			}
+		})
+	}
+}
+
+func TestGetSemantics(t *testing.T) {
+	tests := []struct {
+		fullVersion Version
+		major       string
+		minor       string
+		patch       string
+	}{
+		{
+			fullVersion: Version{"1.2.3"},
+			major:       "1",
+			minor:       "2",
+			patch:       "3",
+		},
+		{
+			fullVersion: Version{"2.2.3"},
+			major:       "2",
+			minor:       "2",
+			patch:       "3",
+		}, {
+			fullVersion: Version{"0.2.3"},
+			major:       "0",
+			minor:       "2",
+			patch:       "3",
+		},
+	}
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, test.major, test.fullVersion.GetMajor())
+			assert.Equal(t, test.minor, test.fullVersion.GetMinor())
+			assert.Equal(t, test.patch, test.fullVersion.GetPatch())
 		})
 	}
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -113,9 +113,38 @@ func TestGetSemantics(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.major, test.fullVersion.GetMajor())
-			assert.Equal(t, test.minor, test.fullVersion.GetMinor())
-			assert.Equal(t, test.patch, test.fullVersion.GetPatch())
+			major, err := test.fullVersion.GetMajor()
+			assert.NoError(t, err)
+			minor, err := test.fullVersion.GetMinor()
+			assert.NoError(t, err)
+			patch, err := test.fullVersion.GetPatch()
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.major, major)
+			assert.Equal(t, test.minor, minor)
+			assert.Equal(t, test.patch, patch)
+		})
+	}
+}
+
+func TestGetSemanticsInvalidFormat(t *testing.T) {
+	tests := []struct {
+		fullVersion Version
+		major       string
+		minor       string
+		patch       string
+	}{
+		{
+			fullVersion: Version{"1.2"},
+			major:       "1",
+			minor:       "2",
+			patch:       "",
+		},
+	}
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			_, err := test.fullVersion.GetMajor()
+			assert.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gofrog#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] I labeled this pull request with one of the following: 'breaking change', 'new feature', 'bug', or 'ignore for release'

---

Add new utility functions to extract major, minor and patch from semantic versioning format
only support semantic versioning format, otherwise returns error
