### PR TITLE
Allow resetting the finish notification of a runner

### DIFF
--- a/parallel/runner_test.go
+++ b/parallel/runner_test.go
@@ -182,7 +182,7 @@ func TestMaxParallel(t *testing.T) {
 	assert.Equal(t, uint32(capacity), runner.started)
 }
 
-func TestResetFinishNotification(t *testing.T) {
+func TestResetFinishNotificationIfActive(t *testing.T) {
 	// Create 2 runners
 	const capacity = 10
 	const parallelism = 3
@@ -194,7 +194,7 @@ func TestResetFinishNotification(t *testing.T) {
 	// Add 10 tasks to runner one. Each task provides tasks to runner two.
 	for i := 0; i < capacity; i++ {
 		_, err := runnerOne.AddTask(func(int) error {
-			time.Sleep(time.Millisecond * 10)
+			time.Sleep(time.Millisecond * 100)
 			_, err := runnerTwo.AddTask(func(int) error {
 				time.Sleep(time.Millisecond)
 				return nil
@@ -220,7 +220,7 @@ func TestResetFinishNotification(t *testing.T) {
 	runnerOne.Run()
 
 	// Reset runner two's finish notification to ensure we receive it only after all tasks assigned to runner two are completed.
-	runnerTwo.ResetFinishNotification()
+	runnerTwo.ResetFinishNotificationIfActive()
 
 	// Receive the finish notification and ensure that we have truly completed the task.
 	<-runnerTwo.GetFinishedNotification()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gofrog#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] I labeled this pull request with one of the following: 'breaking change', 'new feature', 'bug', or 'ignore for release'

---

Dependency for https://github.com/jfrog/jfrog-cli-core/pull/1086
Imagine this scenario: there are two runners, "One" and "Two". One assigns tasks to Two.
At times, Two might have no tasks. When this occurs, Two's finish notification could trigger prematurely.
To tackle this rare situation, this PR introduces an option to reset the finish notification. After One finishes its tasks, the user can reset Two's finish notification. This ensures that when we await Two's finish notification, we're fully covered.