### PR TITLE
Fix `io.Close()` nil error parameter

### DIFF
--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -247,7 +247,6 @@ func Close(closer io.Closer, err *error) {
 
 	closeErr = fmt.Errorf("failed to close %T: %w", closer, closeErr)
 	if err == nil {
-		err = &closeErr
 		return
 	}
 	*err = errors.Join(*err, closeErr)

--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -244,11 +244,11 @@ func Close(closer io.Closer, err *error) {
 	if closeErr = closer.Close(); closeErr == nil {
 		return
 	}
+
 	closeErr = fmt.Errorf("failed to close %T: %w", closer, closeErr)
 	if err == nil {
 		err = &closeErr
 		return
 	}
 	*err = errors.Join(*err, closeErr)
-	return
 }

--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -246,8 +246,7 @@ func Close(closer io.Closer, err *error) {
 	}
 
 	closeErr = fmt.Errorf("failed to close %T: %w", closer, closeErr)
-	if err == nil {
-		return
+	if err != nil {
+		*err = errors.Join(*err, closeErr)
 	}
-	*err = errors.Join(*err, closeErr)
 }

--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -240,7 +240,15 @@ func GetFileInfo(path string, followSymlink bool) (fileInfo os.FileInfo, err err
 
 // Close the reader/writer and append the error to the given error.
 func Close(closer io.Closer, err *error) {
-	if closeErr := closer.Close(); closeErr != nil {
-		*err = errors.Join(*err, fmt.Errorf("failed to close %T: %w", closer, closeErr))
+	var closeErr error
+	if closeErr = closer.Close(); closeErr == nil {
+		return
 	}
+	closeErr = fmt.Errorf("failed to close %T: %w", closer, closeErr)
+	if err == nil {
+		err = &closeErr
+		return
+	}
+	*err = errors.Join(*err, closeErr)
+	return
 }

--- a/io/fileutils_test.go
+++ b/io/fileutils_test.go
@@ -31,7 +31,3 @@ func TestClose(t *testing.T) {
 	Close(f, nilErr)
 	assert.NotNil(t, nilErr)
 }
-
-func getNilErr() error {
-	return nil
-}

--- a/io/fileutils_test.go
+++ b/io/fileutils_test.go
@@ -2,17 +2,17 @@ package io
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClose(t *testing.T) {
 	var err error
-	t.TempDir()
-	f, err := os.Create(path.Join(t.TempDir(), "test"))
+	f, err := os.Create(filepath.Join(t.TempDir(), "test"))
 	assert.NoError(t, err)
 
 	Close(f, &err)
@@ -26,4 +26,12 @@ func TestClose(t *testing.T) {
 	err = errors.New("original error")
 	Close(f, &err)
 	assert.Len(t, strings.Split(err.Error(), "\n"), 2)
+
+	nilErr := new(error)
+	Close(f, nilErr)
+	assert.NotNil(t, nilErr)
+}
+
+func getNilErr() error {
+	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gofrog#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] I labeled this pull request with one of the following: 'breaking change', 'new feature', 'bug', or 'ignore for release'

---
- Prevents code from panic when the `err` parameter is nil.