### PR TITLE
Allow moving file to a destination without write permissions

### DIFF
--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jfrog/gofrog/log"
 )
 
 const (
@@ -325,8 +327,7 @@ func MoveFile(sourcePath, destPath string) (err error) {
 		return
 	}
 
-	var outputFile *os.File
-	outputFile, err = os.Create(destPath)
+	outputFile, err := createFileForWriting(destPath)
 	if err != nil {
 		return
 	}
@@ -351,6 +352,25 @@ func MoveFile(sourcePath, destPath string) (err error) {
 	inputFileOpen = false
 	err = os.Remove(sourcePath)
 	return
+}
+
+// Create file for writing. If file already exists, it will be truncated.
+// If the file exists and is read-only, the function will try to change the file permissions to read-write.
+// The caller should update the permissions and close the file when done.
+func createFileForWriting(destPath string) (*os.File, error) {
+	// Try to create the destination file
+	outputFile, err := os.Create(destPath)
+	if err == nil {
+		return outputFile, nil
+	}
+
+	log.Debug("Couldn't open the destination file: '" + destPath + "'. Trying to set the file permissions to read-write.")
+	if err = os.Chmod(destPath, 0600); err != nil {
+		return nil, err
+	}
+
+	// Try to open the destination file again
+	return os.Create(destPath)
 }
 
 // Return the list of files and directories in the specified path

--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -364,7 +364,7 @@ func createFileForWriting(destPath string) (*os.File, error) {
 		return outputFile, nil
 	}
 
-	log.Debug("Couldn't open the destination file: '" + destPath + "'. Trying to set the file permissions to read-write.")
+	log.Debug(fmt.Sprintf("Couldn't to open the destination file: '%s' due to %s. Attempting to set the file permissions to read-write.", destPath, err.Error()))
 	if err = os.Chmod(destPath, 0600); err != nil {
 		return nil, err
 	}

--- a/io/fileutils.go
+++ b/io/fileutils.go
@@ -365,8 +365,8 @@ func createFileForWriting(destPath string) (*os.File, error) {
 	}
 
 	log.Debug(fmt.Sprintf("Couldn't to open the destination file: '%s' due to %s. Attempting to set the file permissions to read-write.", destPath, err.Error()))
-	if err = os.Chmod(destPath, 0600); err != nil {
-		return nil, err
+	if chmodErr := os.Chmod(destPath, 0600); chmodErr != nil {
+		return nil, errors.Join(err, chmodErr)
 	}
 
 	// Try to open the destination file again

--- a/io/fileutils_test.go
+++ b/io/fileutils_test.go
@@ -93,3 +93,70 @@ func TestCreateTempDir(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(tempDir))
 	}()
 }
+
+func TestMoveFile_New(t *testing.T) {
+	// Init test
+	sourcePath, destPath := initMoveTest(t)
+
+	// Move file
+	assert.NoError(t, MoveFile(sourcePath, destPath))
+
+	// Assert expected file paths
+	assert.FileExists(t, destPath)
+	assert.NoFileExists(t, sourcePath)
+}
+
+func TestMoveFile_Override(t *testing.T) {
+	// Init test
+	sourcePath, destPath := initMoveTest(t)
+	err := os.WriteFile(destPath, []byte("dst"), os.ModePerm)
+	assert.NoError(t, err)
+
+	// Move file
+	assert.NoError(t, MoveFile(sourcePath, destPath))
+
+	// Assert file overidden
+	assert.FileExists(t, destPath)
+	destFileContent, err := os.ReadFile(destPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "src", string(destFileContent))
+
+	// Assert source file removed
+	assert.NoFileExists(t, sourcePath)
+}
+
+func TestMoveFile_NoPerm(t *testing.T) {
+	// Init test
+	sourcePath, destPath := initMoveTest(t)
+	err := os.WriteFile(destPath, []byte("dst"), os.ModePerm)
+	assert.NoError(t, err)
+
+	// Remove all permissions from destination file
+	assert.NoError(t, os.Chmod(destPath, 0000))
+	_, err = os.Create(destPath)
+	assert.ErrorContains(t, err, "permission")
+
+	// Move file
+	assert.NoError(t, MoveFile(sourcePath, destPath))
+
+	// Assert file overidden
+	assert.FileExists(t, destPath)
+	destFileContent, err := os.ReadFile(destPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "src", string(destFileContent))
+	
+	// Assert source file removed
+	assert.NoFileExists(t, sourcePath)
+}
+
+func initMoveTest(t *testing.T) (sourcePath, destPath string) {
+	// Create source and destination paths
+	tmpDir := t.TempDir()
+	sourcePath = filepath.Join(tmpDir, "src")
+	destPath = filepath.Join(tmpDir, "dst")
+
+	// Write content to source file
+	err := os.WriteFile(sourcePath, []byte("src"), os.ModePerm)
+	assert.NoError(t, err)
+	return
+}

--- a/io/fileutils_test.go
+++ b/io/fileutils_test.go
@@ -109,7 +109,7 @@ func TestMoveFile_New(t *testing.T) {
 func TestMoveFile_Override(t *testing.T) {
 	// Init test
 	sourcePath, destPath := initMoveTest(t)
-	err := os.WriteFile(destPath, []byte("dst"), os.ModePerm)
+	err := os.WriteFile(destPath, []byte("dst"), 0600)
 	assert.NoError(t, err)
 
 	// Move file
@@ -128,13 +128,13 @@ func TestMoveFile_Override(t *testing.T) {
 func TestMoveFile_NoPerm(t *testing.T) {
 	// Init test
 	sourcePath, destPath := initMoveTest(t)
-	err := os.WriteFile(destPath, []byte("dst"), os.ModePerm)
+	err := os.WriteFile(destPath, []byte("dst"), 0600)
 	assert.NoError(t, err)
 
 	// Remove all permissions from destination file
 	assert.NoError(t, os.Chmod(destPath, 0000))
 	_, err = os.Create(destPath)
-	assert.ErrorContains(t, err, "permission")
+	assert.Error(t, err)
 
 	// Move file
 	assert.NoError(t, MoveFile(sourcePath, destPath))
@@ -156,7 +156,7 @@ func initMoveTest(t *testing.T) (sourcePath, destPath string) {
 	destPath = filepath.Join(tmpDir, "dst")
 
 	// Write content to source file
-	err := os.WriteFile(sourcePath, []byte("src"), os.ModePerm)
+	err := os.WriteFile(sourcePath, []byte("src"), 0600)
 	assert.NoError(t, err)
 	return
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gofrog#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] I labeled this pull request with one of the following: 'breaking change', 'new feature', 'bug', or 'ignore for release'

---

This pull request addresses the following issue:
When a file is copied from A to B, and B is an existing file without write permissions, the operation fails. This pull request resolves the issue by adding read-write permissions to the destination file if opening it for writing fails.
